### PR TITLE
Added coloring of time difference

### DIFF
--- a/ExtraLeaderboardPositions.as
+++ b/ExtraLeaderboardPositions.as
@@ -12,6 +12,8 @@ const array<string> podiumIcon = {
 };
 
 const string resetColor = "\\$z";
+const string blueColor = "\\$77f";
+const string redColor = "\\$f77";
 
 const string pluginName = "Extra Leaderboard positions";
 

--- a/Render/Render.as
+++ b/Render/Render.as
@@ -97,17 +97,19 @@ void Render() {
                     //still keeping the if in case we want to print/add something here
                 }else{
                     int timeDifference = cutoffArray[i].time - timeDifferenceCutoff.time;
+                    string timeDifferenceString = TimeString(Math::Abs(timeDifference));
+                    
                     if(inverseTimeDiffSign){
                         if(timeDifference < 0){
-                            UI::Text("+" + TimeString(Math::Abs(timeDifference)));
+                            UI::Text((showColoredTimeDifference ? redColor : "") + "+" + timeDifferenceString);
                         }else{
-                            UI::Text("-" + TimeString(timeDifference));
+                            UI::Text((showColoredTimeDifference ? blueColor : "") + "-" + timeDifferenceString);
                         }
                     }else{
                         if(timeDifference < 0){
-                            UI::Text("-" + TimeString(Math::Abs(timeDifference)));
+                            UI::Text((showColoredTimeDifference ? blueColor : "") + "-" + timeDifferenceString);
                         }else{
-                            UI::Text("+" + TimeString(timeDifference));
+                            UI::Text((showColoredTimeDifference ? redColor : "") + "+" + timeDifferenceString);
                         }
                     }
                 }

--- a/Render/RenderSettings.as
+++ b/Render/RenderSettings.as
@@ -24,6 +24,8 @@ void RenderSettingsCustomization(){
     if(showTimeDifference){
         inverseTimeDiffSign = UI::Checkbox("Inverse sign (+ instead of -)", inverseTimeDiffSign);
 
+        showColoredTimeDifference = UI::Checkbox("Color the time difference (blue if negative, red otherwise)", showColoredTimeDifference);
+
         UI::Text("\t\tFrom which position should the time difference be shown?");
         string comboText = "";
         if(currentComboChoice == -1){

--- a/Settings/Settings.as
+++ b/Settings/Settings.as
@@ -23,6 +23,9 @@ string allPositionToGetStringSave = "";
 bool showTimeDifference = true;
 
 [Setting hidden]
+bool showColoredTimeDifference = true;
+
+[Setting hidden]
 bool inverseTimeDiffSign = false;
 
 [Setting hidden]

--- a/info.toml
+++ b/info.toml
@@ -2,7 +2,7 @@
 name     = "Extra Leaderboard Positions"
 author   = "Banalian"
 category = "Race"
-version  = "1.3"
+version  = "1.3.1"
 siteid = 169
 
 


### PR DESCRIPTION
Closes #1

![image](https://user-images.githubusercontent.com/64379456/155880867-ff7442b8-4766-47fc-82b4-2db2b87e6915.png)

For now it just colors the text in blue if the time is negative or in red otherwise.

That means that you can have a position above being red or blue depending on if you inversed the time difference or not

![image](https://user-images.githubusercontent.com/64379456/155880941-cd37a3f9-7248-4cd1-a22c-75d7b4cb3f45.png)
