### PR TITLE
WIP: Add percentage ranking

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "echo",
+            "type": "shell",
+            "command": " & 'C:\\Program Files\\7-Zip\\7z.exe' a TestPlugin.op -tzip; mv ./TestPlugin.op C:\\Users\\Thomas\\OpenplanetNext\\Plugins -Force"
+        }
+    ]
+}

--- a/Controller/Functions.as
+++ b/Controller/Functions.as
@@ -292,9 +292,23 @@ void AddMedalsPosition(uint totalPositions){
 
 array<float> GetPercentagesAbovePB(int targets, float pbPercent){
     float nearest = Math::Floor(pbPercent);
-    float nearestFive = Math::Floor(pbPercent / 5) * 5;
-    int nearestTen = Math::Floor(pbPercent / 10) * 10;
-    return {nearest, nearestFive, nearestTen};
+    if(pbPercent > 10){
+        int nearestFive = Math::Floor(pbPercent / 5) * 5;
+        int nearestTen = nearestFive - 5;
+        return {nearest, nearestFive, nearestTen};
+    }
+    else if (pbPercent > 6){
+        return {nearest, nearest - 1, 5};
+    }
+    else if (pbPercent > 3){
+        return {nearest, nearest - 1, 1};
+    }
+    else if (pbPercent > 2){
+        return {nearest, 1};
+    }
+    else {
+        return {nearest};
+    }
 }
 
 void UpdateTimes(){
@@ -328,25 +342,27 @@ void UpdateTimes(){
         }
     }
 
-    int targetsToGet = 3;
-    float pbPercentage = 100.0f * currentPbPosition / totalPlayers;
-    array<float> extraPosPercentage = GetPercentagesAbovePB(3, pbPercentage);
-    for(uint i = 0; i< extraPosPercentage.Length; i++){
-        CutoffTime@ best = CutoffTime();
-        best.time = -1;
-        best.position = -1;
-        best.pb = false;
-        best.percentage = extraPosPercentage[i];
+    if(addTargetRankings){
+        int targetsToGet = 3;
+        float pbPercentage = 100.0f * currentPbPosition / totalPlayers;
+        array<float> extraPosPercentage = GetPercentagesAbovePB(3, pbPercentage);
+        for(uint i = 0; i< extraPosPercentage.Length; i++){
+            CutoffTime@ best = CutoffTime();
+            best.time = -1;
+            best.position = -1;
+            best.pb = false;
+            best.percentage = extraPosPercentage[i];
 
-        int position = totalPlayers * extraPosPercentage[i] / 100;
-        int offset = position - 1;
+            int position = totalPlayers * extraPosPercentage[i] / 100;
+            int offset = position - 1;
 
-        best.position = position;
+            best.position = position;
 
-        best.time = GetTimeWithOffset(offset);
+            best.time = GetTimeWithOffset(offset);
 
-        if(best.time != -1){
-            cutoffArrayTmp.InsertLast(best);
+            if(best.time != -1){
+                cutoffArrayTmp.InsertLast(best);
+            }
         }
     }
 

--- a/Controller/Functions.as
+++ b/Controller/Functions.as
@@ -217,7 +217,7 @@ bool isAValidMedalTime(CutoffTime@ time) {
 }
 
 
-void AddMedalsPosition(){
+void AddMedalsPosition(uint totalPositions){
 
     if(!showMedals){
         return;
@@ -243,6 +243,7 @@ void AddMedalsPosition(){
             if(atTime < currentPbTime || currentPbTime == -1){
                 auto atPosition = GetSpecificTimePosition(atTime);
                 atPosition.desc = "AT";
+                atPosition.percentage = ((100.0f * atPosition.position) / totalPositions);
                 atPosition.isMedal = true;
                 if(isAValidMedalTime(atPosition)) {
                     cutoffArrayTmp.InsertLast(atPosition);
@@ -255,6 +256,7 @@ void AddMedalsPosition(){
             if(goldTime < currentPbTime || currentPbTime == -1){
                 auto goldPosition = GetSpecificTimePosition(goldTime);
                 goldPosition.desc = "Gold";
+                goldPosition.percentage = ((100.0f * goldPosition.position) / totalPositions);
                 goldPosition.isMedal = true;
                 if(isAValidMedalTime(goldPosition)) {
                     cutoffArrayTmp.InsertLast(goldPosition);
@@ -266,6 +268,7 @@ void AddMedalsPosition(){
             if(silverTime < currentPbTime || currentPbTime == -1){
                 auto silverPosition = GetSpecificTimePosition(silverTime);
                 silverPosition.desc = "Silver";
+                silverPosition.percentage = ((100.0f * silverPosition.position) / totalPositions);
                 silverPosition.isMedal = true;
                 if(isAValidMedalTime(silverPosition)) {
                     cutoffArrayTmp.InsertLast(silverPosition);
@@ -277,6 +280,7 @@ void AddMedalsPosition(){
             if(bronzeTime < currentPbTime || currentPbTime == -1){
                 auto bronzePosition = GetSpecificTimePosition(bronzeTime);
                 bronzePosition.desc = "Bronze";
+                bronzePosition.percentage = ((100.0f * bronzePosition.position) / totalPositions);
                 bronzePosition.isMedal = true;
                 if(isAValidMedalTime(bronzePosition)) {
                     cutoffArrayTmp.InsertLast(bronzePosition);
@@ -299,9 +303,12 @@ void UpdateTimes(){
     // We get the 1st, 10th, 100th and 1000th leaderboard time, as well as the personal best time
     cutoffArrayTmp = array<CutoffTime@>();
 
-    cutoffArrayTmp.InsertLast(GetPersonalBest());
-
     int slowestPos = GetSlowestPos();
+
+    auto personalBest = GetPersonalBest();
+    personalBest.percentage = (100.0f * personalBest.position / slowestPos);
+    cutoffArrayTmp.InsertLast(personalBest);
+
     print(slowestPos);
 
     for(uint i = 0; i< allPositionToGet.Length; i++){
@@ -314,6 +321,7 @@ void UpdateTimes(){
         int offset = position - 1;
 
         best.position = position;
+        best.percentage = ((100.0f * position) / slowestPos);
 
         best.time = GetTimeWithOffset(offset);
 
@@ -330,7 +338,7 @@ void UpdateTimes(){
         best.time = -1;
         best.position = -1;
         best.pb = false;
-        best.desc = (extraPosPercentage[i]) + "%";
+        best.percentage = extraPosPercentage[i];
 
         int position = slowestPos * extraPosPercentage[i] / 100;
         int offset = position - 1;
@@ -359,7 +367,7 @@ void UpdateTimes(){
         }
     }
 
-    AddMedalsPosition();
+    AddMedalsPosition(slowestPos);
 
     //sort the array
     cutoffArrayTmp.SortAsc();

--- a/Controller/Functions.as
+++ b/Controller/Functions.as
@@ -45,16 +45,12 @@ Net::HttpRequest@ GetTMIO(const string &in url)
 
 Json::Value GetTMIOAsync(const string &in url)
 {
-    print(url);
     auto req = GetTMIO(url);
     while (!req.Finished()) {
         yield();
     }
-    print(req.ResponseCode());
     return Json::Parse(req.String());
 }
-
-
 
 
 string TimeString(int scoreTime, bool showSign = false) {
@@ -320,8 +316,6 @@ void UpdateTimes(){
     auto personalBest = GetPersonalBest();
     personalBest.percentage = (100.0f * personalBest.position / totalPlayers);
     cutoffArrayTmp.InsertLast(personalBest);
-
-    print(totalPlayers);
 
     for(uint i = 0; i< allPositionToGet.Length; i++){
         CutoffTime@ best = CutoffTime();

--- a/Controller/Functions.as
+++ b/Controller/Functions.as
@@ -288,6 +288,13 @@ void AddMedalsPosition(){
 
 }
 
+array<float> GetPercentagesAbovePB(int targets, float pbPercent){
+    float nearest = Math::Floor(pbPercent);
+    float nearestFive = Math::Floor(pbPercent / 5) * 5;
+    int nearestTen = Math::Floor(pbPercent / 10) * 10;
+    return {nearest, nearestFive, nearestTen};
+}
+
 void UpdateTimes(){
     // We get the 1st, 10th, 100th and 1000th leaderboard time, as well as the personal best time
     cutoffArrayTmp = array<CutoffTime@>();
@@ -315,15 +322,17 @@ void UpdateTimes(){
         }
     }
 
-    array<uint> extraPosToGet = {10, 20, 50, 80, 100};
-    for(uint i = 0; i< extraPosToGet.Length; i++){
+    int targetsToGet = 3;
+    float pbPercentage = 100.0f * currentPbPosition / slowestPos;
+    array<float> extraPosPercentage = GetPercentagesAbovePB(3, pbPercentage);
+    for(uint i = 0; i< extraPosPercentage.Length; i++){
         CutoffTime@ best = CutoffTime();
         best.time = -1;
         best.position = -1;
         best.pb = false;
-        best.desc = extraPosToGet[i] + "%";
+        best.desc = (extraPosPercentage[i]) + "%";
 
-        int position = slowestPos * extraPosToGet[i] / 100;
+        int position = slowestPos * extraPosPercentage[i] / 100;
         int offset = position - 1;
 
         best.position = position;

--- a/ExtraLeaderboardPositions.as
+++ b/ExtraLeaderboardPositions.as
@@ -87,7 +87,7 @@ void Main(){
     startupEnded = true;
     // Add the audiences you need
     NadeoServices::AddAudience("NadeoLiveServices");
- 
+
     // Wait until the services are authenticated
     while (!NadeoServices::IsAuthenticated("NadeoLiveServices")) {
       yield();

--- a/Model/CutoffTime.as
+++ b/Model/CutoffTime.as
@@ -16,6 +16,8 @@ class CutoffTime{
     // really short description of the record
     string desc = "";
 
+    string percentage = "";
+
     // Comparaison operator
     int opCmp(CutoffTime@ other){
         if(position - other.position != 0)

--- a/Model/CutoffTime.as
+++ b/Model/CutoffTime.as
@@ -16,7 +16,9 @@ class CutoffTime{
     // really short description of the record
     string desc = "";
 
-    string percentage = "";
+    float percentage = 0.0f;
+
+    string percentageDisplay = "";
 
     // Comparaison operator
     int opCmp(CutoffTime@ other){

--- a/Render/Render.as
+++ b/Render/Render.as
@@ -105,9 +105,10 @@ void RenderTab(){
     UI::Text("Time");
     UI::TableNextColumn();
     UI::TableNextColumn();
-    UI::Text("%");
+    if(showRanking){
+        UI::Text("%");
+    }
     if(refreshPosition){
-        UI::TableNextColumn();
         UI::TableNextColumn();
         UI::Text("Refreshing...");
     }
@@ -160,7 +161,7 @@ void RenderTab(){
 
         //------------%--------------------
         UI::TableNextColumn();
-        if(cutoffArray[i].percentage != 0.0f){
+        if(showRanking && cutoffArray[i].percentage != 0.0f){
             UI::Text(displayString + cutoffArray[i].percentageDisplay);
         }
 

--- a/Render/Render.as
+++ b/Render/Render.as
@@ -161,7 +161,7 @@ void RenderTab(){
         //------------%--------------------
         UI::TableNextColumn();
         if(cutoffArray[i].percentage != 0.0f){
-            UI::Text(displayString + Text::Format("%.02f%%", (cutoffArray[i].percentage)));
+            UI::Text(displayString + cutoffArray[i].percentageDisplay);
         }
 
         //------------TIME DIFFERENCE------

--- a/Render/Render.as
+++ b/Render/Render.as
@@ -41,8 +41,8 @@ void Render() {
 
         RenderWindows();
     }
-    
-    
+
+
 }
 
 void RenderInterface(){
@@ -58,7 +58,7 @@ void RenderInterface(){
 
 void RenderWindows(){
     auto app = cast<CTrackMania>(GetApp());
-    
+
     int windowFlags = UI::WindowFlags::NoTitleBar | UI::WindowFlags::NoCollapse | UI::WindowFlags::AlwaysAutoResize | UI::WindowFlags::NoDocking;
     bool showRefreshButton = false;
 
@@ -74,7 +74,7 @@ void RenderWindows(){
     if(cutoffArray.Length == 1 && cutoffArray[0].position == -1){
         return;
     }
-        
+
 
     if(windowVisible && app.CurrentPlayground !is null){
         UI::Begin(pluginName, windowFlags);
@@ -82,7 +82,7 @@ void RenderWindows(){
         UI::BeginGroup();
 
         UI::Text("Extra leaderboard positions");
-        
+
         RenderTab();
 
         RenderRefreshButton();
@@ -95,7 +95,7 @@ void RenderWindows(){
 
 // Render the table with the custom leaderboard
 void RenderTab(){
-    UI::BeginTable("Main", 5);        
+    UI::BeginTable("Main", 6);
 
     UI::TableNextRow();
     UI::TableNextColumn();
@@ -103,6 +103,9 @@ void RenderTab(){
     UI::Text("Position");
     UI::TableNextColumn();
     UI::Text("Time");
+    UI::TableNextColumn();
+    UI::TableNextColumn();
+    UI::Text("%");
     if(refreshPosition){
         UI::TableNextColumn();
         UI::TableNextColumn();
@@ -126,7 +129,7 @@ void RenderTab(){
                     break;
                 case EnumDisplayMedal::IN_GREY:
                     displayString = greyColor;
-                    break;                   
+                    break;
                 default:
                     break;
             }
@@ -136,7 +139,7 @@ void RenderTab(){
         UI::TableNextRow();
         UI::TableNextColumn();
         UI::Text(GetIconForPosition(cutoffArray[i].position));
-        
+
         //------------POSITION-------------
         UI::TableNextColumn();
         if(cutoffArray[i].position > 10000){
@@ -144,7 +147,7 @@ void RenderTab(){
         }else{
             UI::Text(displayString + "" + cutoffArray[i].position);
         }
-        
+
         //------------TIME-----------------
         UI::TableNextColumn();
         UI::Text(displayString + TimeString(cutoffArray[i].time));
@@ -154,7 +157,13 @@ void RenderTab(){
         if(cutoffArray[i].desc != ""){
             UI::Text(displayString + cutoffArray[i].desc);
         }
-        
+
+        //------------%--------------------
+        UI::TableNextColumn();
+        if(cutoffArray[i].percentage != 0.0f){
+            UI::Text(displayString + Text::Format("%.02f%%", (cutoffArray[i].percentage)));
+        }
+
         //------------TIME DIFFERENCE------
         UI::TableNextColumn();
 
@@ -167,7 +176,7 @@ void RenderTab(){
             }else{
                 int timeDifference = cutoffArray[i].time - timeDifferenceCutoff.time;
                 string timeDifferenceString = TimeString(Math::Abs(timeDifference));
-                
+
                 if(inverseTimeDiffSign){
                     if(timeDifference < 0){
                         UI::Text((showColoredTimeDifference ? redColor : "") + "+" + timeDifferenceString);
@@ -185,7 +194,7 @@ void RenderTab(){
         }
 
         i++;
-            
+
     }
 
     UI::EndTable();

--- a/Render/RenderSettings.as
+++ b/Render/RenderSettings.as
@@ -12,6 +12,7 @@ void RenderSettingsCustomization(){
         refreshTimer = 5;
         showPb = true;
         showRanking = true;
+        addTargetRankings = true;
         showTimeDifference = true;
         showColoredTimeDifference = true;
         inverseTimeDiffSign = false;
@@ -37,6 +38,7 @@ void RenderSettingsCustomization(){
 
     UI::Text("\n\tPercentage ranking");
     showRanking = UI::Checkbox("Show ranking column", showRanking);
+    addTargetRankings = UI::Checkbox("Add target rankings", addTargetRankings);
 
     UI::Text("\n\tTime difference");
     showTimeDifference = UI::Checkbox("Show time difference", showTimeDifference);

--- a/Render/RenderSettings.as
+++ b/Render/RenderSettings.as
@@ -11,6 +11,7 @@ void RenderSettingsCustomization(){
         hiddingSpeedSetting = 1.0f;
         refreshTimer = 5;
         showPb = true;
+        showRanking = true;
         showTimeDifference = true;
         showColoredTimeDifference = true;
         inverseTimeDiffSign = false;
@@ -34,6 +35,8 @@ void RenderSettingsCustomization(){
 
     showPb = UI::Checkbox("Show personal best", showPb);
 
+    UI::Text("\n\tPercentage ranking");
+    showRanking = UI::Checkbox("Show ranking column", showRanking);
 
     UI::Text("\n\tTime difference");
     showTimeDifference = UI::Checkbox("Show time difference", showTimeDifference);
@@ -63,10 +66,10 @@ void RenderSettingsCustomization(){
             }
             UI::EndCombo();
         }
-            
+
 
     }
-    
+
 }
 
 [SettingsTab name="Explanation"]

--- a/Settings/Settings.as
+++ b/Settings/Settings.as
@@ -19,6 +19,8 @@ bool showPb = true;
 
 [Setting hidden]
 bool showRanking = true;
+[Setting hidden]
+bool addTargetRankings = true;
 
 [Setting hidden]
 bool showMedals = true;

--- a/Settings/Settings.as
+++ b/Settings/Settings.as
@@ -17,6 +17,8 @@ int refreshTimer = 5;
 [Setting hidden]
 bool showPb = true;
 
+[Setting hidden]
+bool showRanking = true;
 
 [Setting hidden]
 bool showMedals = true;


### PR DESCRIPTION
- Add a setting to show a column with the percentage ranking for each record
- Add a setting to add three targets (floor PB percent, nearest 5%, 5% higher than that, or smaller increments when <10%)

TODO:
- Cache TMIO call
- A more compact display?
- Improve targets?
- Easy switch to display positions by number?
- Alter positions to allow position *or* percent?