### PR TITLE
Add just percentage ranking

### DIFF
--- a/Controller/Main.as
+++ b/Controller/Main.as
@@ -29,12 +29,13 @@ void RefreshLeaderboard(){
     // if activated, call the extra leaderboardAPI
     if(ExtraLeaderboardAPI::Active && useExternalAPI && !ExtraLeaderboardAPI::failedAPI){
 
-        ExtraLeaderboardAPI::ExtraLeaderboardAPIRequest@ req = null; 
-        try 
+        bool needPlayerCount = showPlayerCount || showPercentage;
+        ExtraLeaderboardAPI::ExtraLeaderboardAPIRequest@ req = null;
+        try
         {
-           @req = ExtraLeaderboardAPI::PrepareRequest(showPlayerCount);
-        } 
-        catch 
+           @req = ExtraLeaderboardAPI::PrepareRequest(needPlayerCount);
+        }
+        catch
         {
             // we can assume that something went wrong while trying to prepare the request. We abort the refresh and try again later
             // also warn in the log that something went wrong
@@ -55,7 +56,7 @@ void RefreshLeaderboard(){
         respLog = resp;
 
         // if there's a player count, try to extract it and set the player count
-        if(showPlayerCount && resp.playerCount > 0){
+        if(needPlayerCount && resp.playerCount > 0){
             playerCount = resp.playerCount;
         } else {
             playerCount = -1;
@@ -151,6 +152,19 @@ void RefreshLeaderboard(){
             if(leaderboardArrayTmp[i].position == currentComboChoice){
                 timeDifferenceEntry = leaderboardArrayTmp[i];
                 break;
+            }
+        }
+    }
+
+    if(showPercentage && playerCount > 0){
+        for(uint i = 0; i< leaderboardArrayTmp.Length; i++){
+
+            leaderboardArrayTmp[i].percentage = ((100.0f * leaderboardArrayTmp[i].position) / playerCount);
+            if(leaderboardArrayTmp[i].percentage % 1 == 0) {
+                leaderboardArrayTmp[i].percentageDisplay = Text::Format("%.0f%%", leaderboardArrayTmp[i].percentage);
+            }
+            else {
+                leaderboardArrayTmp[i].percentageDisplay = Text::Format("%.02f%%", leaderboardArrayTmp[i].percentage);
             }
         }
     }

--- a/Model/LeaderboardEntry.as
+++ b/Model/LeaderboardEntry.as
@@ -17,6 +17,10 @@ class LeaderboardEntry{
      */
     string desc = "";
 
+    float percentage = 0.0f;
+
+    string percentageDisplay = "";
+
     /**
      * Type of the entry (medal, custom, etc...)
      */

--- a/Render/Render.as
+++ b/Render/Render.as
@@ -203,20 +203,35 @@ bool RenderInfoTab(){
  * Render the table with the custom leaderboard
  */
 void RenderTab(bool showRefresh = false){
-    UI::BeginTable("Main", 6);
+    int columnCount = 4;
+    if(showPercentage){
+        columnCount++;
+    }
+    if(showTimeDifference){
+        columnCount++;
+    }
+    UI::BeginTable("Main", columnCount);
 
     UI::TableNextRow();
+    // Icon
     UI::TableNextColumn();
+    // Position
     UI::TableNextColumn();
     UI::Text("Position");
+    // Time
     UI::TableNextColumn();
     UI::Text("Time");
+    // Desc
     UI::TableNextColumn();
-    UI::TableNextColumn();
+    // %
     if(showPercentage){
+        UI::TableNextColumn();
         UI::Text("%");
     }
-    // UI::TableNextColumn();
+    // Time diff
+    if(showTimeDifference){
+        UI::TableNextColumn();
+    }
     if(showRefresh){
         RenderRefreshIcon();
     }
@@ -271,15 +286,16 @@ void RenderTab(bool showRefresh = false){
         }
 
         //------------%--------------------
-        UI::TableNextColumn();
-        if(showPercentage && leaderboardArray[i].percentage != 0.0f){
-            UI::Text(displayString + leaderboardArray[i].percentageDisplay);
+        if(showPercentage){
+            UI::TableNextColumn();
+            if(leaderboardArray[i].percentage != 0.0f){
+                UI::Text(displayString + leaderboardArray[i].percentageDisplay);
+            }
         }
 
         //------------TIME DIFFERENCE------
-        UI::TableNextColumn();
-
         if(showTimeDifference){
+            UI::TableNextColumn();
             if(leaderboardArray[i].time == -1 || timeDifferenceEntry.time == -1){
                 //Nothing here, no time to compare to
             }else if(leaderboardArray[i].customEquals(timeDifferenceEntry)){

--- a/Render/Render.as
+++ b/Render/Render.as
@@ -203,8 +203,8 @@ bool RenderInfoTab(){
  * Render the table with the custom leaderboard
  */
 void RenderTab(bool showRefresh = false){
-    UI::BeginTable("Main", 5);        
-    
+    UI::BeginTable("Main", 6);
+
     UI::TableNextRow();
     UI::TableNextColumn();
     UI::TableNextColumn();
@@ -212,6 +212,11 @@ void RenderTab(bool showRefresh = false){
     UI::TableNextColumn();
     UI::Text("Time");
     UI::TableNextColumn();
+    UI::TableNextColumn();
+    if(showPercentage){
+        UI::Text("%");
+    }
+    // UI::TableNextColumn();
     if(showRefresh){
         RenderRefreshIcon();
     }
@@ -264,7 +269,13 @@ void RenderTab(bool showRefresh = false){
         if(leaderboardArray[i].desc != ""){
             UI::Text(displayString + leaderboardArray[i].desc);
         }
-        
+
+        //------------%--------------------
+        UI::TableNextColumn();
+        if(showPercentage && leaderboardArray[i].percentage != 0.0f){
+            UI::Text(displayString + leaderboardArray[i].percentageDisplay);
+        }
+
         //------------TIME DIFFERENCE------
         UI::TableNextColumn();
 

--- a/Render/RenderSettings.as
+++ b/Render/RenderSettings.as
@@ -11,6 +11,7 @@ void RenderSettingsCustomization(){
         hiddingSpeedSetting = 1.0f;
         refreshTimer = 5;
         showPb = true;
+        showPercentage = false;
         showTimeDifference = true;
         showColoredTimeDifference = true;
         inverseTimeDiffSign = false;
@@ -40,6 +41,14 @@ void RenderSettingsCustomization(){
     UI::Text("\n\tPersonal best");
 
     showPb = UI::Checkbox("Show personal best", showPb);
+
+    UI::BeginDisabled(!useExternalAPI);
+
+    UI::Text("\n\tPercentage ranking");
+
+    showPercentage = UI::Checkbox("Show percentage column (requires External API)", showPercentage && useExternalAPI);
+
+    UI::EndDisabled();
 
     UI::Text("\n\tPosition Representation");
 

--- a/Settings/Settings.as
+++ b/Settings/Settings.as
@@ -23,6 +23,8 @@ int refreshTimer = 5;
 [Setting hidden]
 bool showPb = true;
 
+[Setting hidden]
+bool showPercentage = false;
 
 [Setting hidden]
 bool showMedals = true;


### PR DESCRIPTION
This is basically just a re-application of https://github.com/Banalian/ExtraLeaderboardPositions/pull/8 to use your new API functions but reducing it to the simple first part of just the percentage column without any extra positions.

It adds a single setting "Show percentage column" which can only be ticked when the External API is enabled. This setting forces the total player count to be fetched from the API, then calculates the percentage ranking for every position.

It also slightly adjusts the table rendering to count columns (to avoid the empty column padding on the right).

I might do the extra positions based off % next :)