### PR TITLE
Use `NadeoServices::BaseURLLive()` instead of `NadeoServices::BaseURL()`

### DIFF
--- a/Controller/GatheringFunc.as
+++ b/Controller/GatheringFunc.as
@@ -20,9 +20,9 @@ LeaderboardEntry@ GetPersonalBestEntry() {
     //check that we're in a map
     if (network.ClientManiaAppPlayground !is null && network.ClientManiaAppPlayground.Playground !is null && network.ClientManiaAppPlayground.Playground.Map !is null){
         string mapid = network.ClientManiaAppPlayground.Playground.Map.MapInfo.MapUid;
-        
-        auto info = FetchEndpoint(NadeoServices::BaseURL() + "/api/token/leaderboard/group/Personal_Best/map/"+mapid+"/surround/0/0?onlyWorld=true");
-    
+
+        auto info = FetchEndpoint(NadeoServices::BaseURLLive() + "/api/token/leaderboard/group/Personal_Best/map/"+mapid+"/surround/0/0?onlyWorld=true");
+
         if(info.GetType() != Json::Type::Null) {
             auto tops = info["tops"];
             if(tops.GetType() == Json::Type::Array) {
@@ -57,8 +57,8 @@ LeaderboardEntry@ GetSpecificTimeEntry(int position) {
 
     //check that we're in a map
     if (network.ClientManiaAppPlayground !is null && network.ClientManiaAppPlayground.Playground !is null && network.ClientManiaAppPlayground.Playground.Map !is null){
-        auto info = FetchEndpoint(NadeoServices::BaseURL() + "/api/token/leaderboard/group/Personal_Best/map/"+currentMapUid+"/top?length=1&offset="+offset+"&onlyWorld=true");
-    
+        auto info = FetchEndpoint(NadeoServices::BaseURLLive() + "/api/token/leaderboard/group/Personal_Best/map/"+currentMapUid+"/top?length=1&offset="+offset+"&onlyWorld=true");
+
         if(info.GetType() != Json::Type::Null) {
             auto tops = info["tops"];
             if(tops.GetType() == Json::Type::Array) {
@@ -95,9 +95,9 @@ LeaderboardEntry@ GetSpecificPositionEntry(int time) {
     //check that we're in a map
     if (network.ClientManiaAppPlayground !is null && network.ClientManiaAppPlayground.Playground !is null && network.ClientManiaAppPlayground.Playground.Map !is null){
         string mapid = network.ClientManiaAppPlayground.Playground.Map.MapInfo.MapUid;
-        
-        auto info = FetchEndpoint(NadeoServices::BaseURL() + "/api/token/leaderboard/group/Personal_Best/map/"+mapid+"/surround/0/0?score="+time+"&onlyWorld=true");
-    
+
+        auto info = FetchEndpoint(NadeoServices::BaseURLLive() + "/api/token/leaderboard/group/Personal_Best/map/"+mapid+"/surround/0/0?score="+time+"&onlyWorld=true");
+
         if(info.GetType() != Json::Type::Null) {
             auto tops = info["tops"];
             if(tops.GetType() == Json::Type::Array) {

--- a/Controller/Toolbox.as
+++ b/Controller/Toolbox.as
@@ -27,7 +27,7 @@ bool isAValidMedalTime(LeaderboardEntry@ time) {
  * Needs to be called from a yieldable function
  */
 bool MapHasNadeoLeaderboard(const string &in mapId){
-    auto info = FetchEndpoint(NadeoServices::BaseURL() + "/api/token/map/" + mapId);
+    auto info = FetchEndpoint(NadeoServices::BaseURLLive() + "/api/token/map/" + mapId);
 
     return info.GetType() == Json::Type::Object;
 }


### PR DESCRIPTION
`NadeoServices::BaseURL()` was deprecated in Openplanet 1.25.45 (openplanet-nl/nadeoservices@b6344e6d), causing a number of warnings to be printed to the Openplanet log every time the plugin refreshes the leaderboard.

Note that this change means the plugin will now require Openplanet ≥ 1.25.45, as `BaseURLLive()` was only introduced in this version (the same version that deprecated `BaseURL()`).