### PR TITLE
fix: early pb update, refresh icon tooltip

### DIFF
--- a/API/ExtraLeaderboardAPI.as
+++ b/API/ExtraLeaderboardAPI.as
@@ -124,8 +124,8 @@ namespace ExtraLeaderboardAPI
         int champTime = ChampionMedals::GetCMTime();
         if(
             champTime != 0 && // if the medal exists
-            showChampionMedals && // if the user wants to show it
-            (((champTime < currentPbTime) || currentPbTime == -1) || showMedalWhenBetter) // if the medal is better than the PB or if the user wants to show it anyway
+            showMedals && showChampionMedals && // if the user wants to show it
+            (((champTime < currentPbEntry.time) || currentPbEntry.time == -1) || showMedalWhenBetter) // if the medal is better than the PB or if the user wants to show it anyway
     
         ){
             request.scores.InsertLast(champTime);
@@ -136,8 +136,8 @@ namespace ExtraLeaderboardAPI
         int sbVilleTime = SBVilleCampaignChallenges::getChallengeTime();
         if(
             sbVilleTime != 0 && // if the medal exists
-            showSBVilleATMedal && // if the user wants to show it
-            (((sbVilleTime < currentPbTime) || currentPbTime == -1) || showMedalWhenBetter) // if the medal is better than the PB or if the user wants to show it anyway
+            showMedals && showSBVilleATMedal && // if the user wants to show it
+            (((sbVilleTime < currentPbEntry.time) || currentPbEntry.time == -1) || showMedalWhenBetter) // if the medal is better than the PB or if the user wants to show it anyway
     
         ){
             request.scores.InsertLast(sbVilleTime);
@@ -156,6 +156,8 @@ namespace ExtraLeaderboardAPI
  * Isn't in toolbox since it's some "private" function only used in this namespace(and above function)
  */
 bool ShouldRequestMedal(MedalType medal){
+    if (!showMedals) return false;
+
     auto app = GetApp();
     auto map = app.RootMap;
 
@@ -181,8 +183,8 @@ bool ShouldRequestMedal(MedalType medal){
     }
 
     // Check if the medal is better than the PB or if the user wants to show it anyway
-    if(shouldShow && currentPbTime != -1){
-        shouldShow =  medalTime < currentPbTime || showMedalWhenBetter;
+    if(shouldShow && currentPbEntry.time != -1){
+        shouldShow =  medalTime < currentPbEntry.time || showMedalWhenBetter;
     }
 
     return shouldShow;

--- a/Controller/GatheringFunc.as
+++ b/Controller/GatheringFunc.as
@@ -30,8 +30,6 @@ LeaderboardEntry@ GetPersonalBestEntry() {
                 if(top.Length > 0) {
                     pbTimeTmp.time = top[0]["score"];
                     pbTimeTmp.position = top[0]["position"];
-                    currentPbTime = pbTimeTmp.time;
-                    currentPbPosition = pbTimeTmp.position;
                 }
             }
         }
@@ -171,7 +169,7 @@ array<LeaderboardEntry@> GetMedalsEntries(){
 
         // We get the positions of the 4 medals and add them if they are valid and if we need to show them
         if(showAT){
-            if(atTime < currentPbTime || currentPbTime == -1){
+            if(atTime < currentPbEntry.time || currentPbEntry.time == -1){
                 auto atPosition = GetSpecificPositionEntry(atTime);
                 atPosition.desc = "AT";
                 atPosition.entryType = EnumLeaderboardEntryType::MEDAL;
@@ -183,7 +181,7 @@ array<LeaderboardEntry@> GetMedalsEntries(){
         }
 
         if(showGold){
-            if(goldTime < currentPbTime || currentPbTime == -1){
+            if(goldTime < currentPbEntry.time || currentPbEntry.time == -1){
                 auto goldPosition = GetSpecificPositionEntry(goldTime);
                 goldPosition.desc = "Gold";
                 goldPosition.entryType = EnumLeaderboardEntryType::MEDAL;
@@ -194,7 +192,7 @@ array<LeaderboardEntry@> GetMedalsEntries(){
         }
 
         if(showSilver){
-            if(silverTime < currentPbTime || currentPbTime == -1){
+            if(silverTime < currentPbEntry.time || currentPbEntry.time == -1){
                 auto silverPosition = GetSpecificPositionEntry(silverTime);
                 silverPosition.desc = "Silver";
                 silverPosition.entryType = EnumLeaderboardEntryType::MEDAL;
@@ -205,7 +203,7 @@ array<LeaderboardEntry@> GetMedalsEntries(){
         }
 
         if(showBronze){
-            if(bronzeTime < currentPbTime || currentPbTime == -1){
+            if(bronzeTime < currentPbEntry.time || currentPbEntry.time == -1){
                 auto bronzePosition = GetSpecificPositionEntry(bronzeTime);
                 bronzePosition.desc = "Bronze";
                 bronzePosition.entryType = EnumLeaderboardEntryType::MEDAL;

--- a/Controller/Main.as
+++ b/Controller/Main.as
@@ -269,10 +269,3 @@ void UpdateTimeDifferenceEntry(array<LeaderboardEntry@> arrayTmp) {
         }
     }
 }
-
-string TimeLogString(int time) {
-    if (time >= 0)
-        return time + " [" + Time::Format(time) + "]";
-    else
-        return time + "";
-}

--- a/Controller/Toolbox.as
+++ b/Controller/Toolbox.as
@@ -8,7 +8,7 @@ bool isAValidMedalTime(LeaderboardEntry@ time) {
         return false;
     }
 
-    if(time.position == currentPbPosition && time.time == currentPbTime) {
+    if(time.position == currentPbEntry.position && time.time == currentPbEntry.time) {
         return false;
     }
 
@@ -37,13 +37,13 @@ bool MapHasNadeoLeaderboard(const string &in mapId){
  * also remove the "failed request" lock
  */
 void ForceRefresh(){
-    failedRefresh = false;
-    counterTries = 0;
-    if(!refreshPosition){
-            refreshPosition = true;
+    // don't interfere if refresh already running
+    if (!refreshPosition) {
+        timer = 0;
+        failedRefresh = false;
+        refreshPosition = true;
     }
 }
-
 
 /**
  * Check if the user can use the plugin or not, based on different conditions
@@ -114,15 +114,15 @@ bool newPBSet(int timePbLocal) {
     if(!validMap){
         return false;
     }
-    bool isLocalPbDifferent = timePbLocal != currentPbTime;
+    bool isLocalPbDifferent = timePbLocal != currentPbEntry.time;
     if(isLocalPbDifferent){
         if(timePbLocal == -1){
             return false;
         }
-        if(currentPbTime == -1){
+        if(currentPbEntry.time == -1){
             return true;
         }
-        if(timePbLocal < currentPbTime){
+        if(timePbLocal < currentPbEntry.time){
             return true;
         }else{
             return false;

--- a/Controller/Toolbox.as
+++ b/Controller/Toolbox.as
@@ -108,6 +108,16 @@ string TimeString(int scoreTime, bool showSign = false) {
 }
 
 /**
+ * Format the time for logging with both integer value and readable string representation
+ */
+string TimeLogString(int time) {
+    if (time >= 0)
+        return time + " [" + Time::Format(time) + "]";
+    else
+        return time + "";
+}
+
+/**
  * Check if the new time is a new PB
  */
 bool newPBSet(int timePbLocal) {

--- a/Controller/Update.as
+++ b/Controller/Update.as
@@ -26,34 +26,29 @@ void Update(float dt) {
             timePbLocal = scoreMgr.Map_GetRecord_v2(userId, app.RootMap.MapInfo.MapUid, "PersonalBest", "", "TimeAttack", "");
         }
 
+        if (timePbLocal > 0 && currentTimePbLocal != timePbLocal) {
+            currentTimePbLocal = timePbLocal;
+            trace("Update(): new PB: " + TimeLogString(currentTimePbLocal));
+        }
+
         //if the map change, or the timer is over or a new pb is found, we refresh the positions
-        if (mapIdChanged || timer > updateFrequency || newPBSet(timePbLocal)) {
-
-            if(mapIdChanged){
-                currentMapUid = app.RootMap.MapInfo.MapUid;
-                currentPbTime = -1;
-                playerCount = -1;
-            }
-
-            //we remove the "lock" if the change was a map change or the timer
-            if(mapIdChanged || timer > updateFrequency){
-                    failedRefresh = false;
-                    counterTries = 0;
-            }
-
-
-            //we refresh the positions if the lock is not set
-            if(!failedRefresh){
-                refreshPosition = true;
-            } 
-
-            timer = 0;
+        if (mapIdChanged) {
+            currentMapUid = app.RootMap.MapInfo.MapUid;
+            trace("Update(): new map uid: " + currentMapUid);
+            playerCount = -1;
+            ClearLeaderboard();
+            ForceRefresh();
+        } else if (newPBSet(currentTimePbLocal) || timer > updateFrequency) {
+            ForceRefresh();
         } else {
             timer += dt;
         }
     } else {
         timer = 0;
         currentMapUid = "";
+        refreshPosition = false;
+        currentTimePbLocal = -1;
+        ClearLeaderboard();
     }
 
     // update the config timer

--- a/ExtraLeaderboardPositions.as
+++ b/ExtraLeaderboardPositions.as
@@ -56,14 +56,10 @@ void Main(){
                     RefreshLeaderboard();
                 }else{
                     validMap = false;
-                    if(leaderboardArray.Length > 0){
-                        leaderboardArray = array<LeaderboardEntry@>();
-                    }
+                    ClearLeaderboard();
                 }
             }else{
-                if(leaderboardArray.Length > 0){
-                    leaderboardArray = array<LeaderboardEntry@>();
-                }
+                ClearLeaderboard();
             }
 
             refreshPosition = false;
@@ -102,4 +98,14 @@ bool CanRefresh(){
     }
 
     return true;
+}
+
+void ClearLeaderboard() {
+    if(leaderboardArray.Length > 0){
+        leaderboardArray = array<LeaderboardEntry@>();
+    }
+    currentPbEntry = LeaderboardEntry();
+    currentPbEntry.entryType = EnumLeaderboardEntryType::PB;
+    currentPbEntry.desc = "PB";
+    timeDifferenceEntry = LeaderboardEntry();
 }

--- a/ExtraLeaderboardPositions.as
+++ b/ExtraLeaderboardPositions.as
@@ -104,8 +104,8 @@ void ClearLeaderboard() {
     if(leaderboardArray.Length > 0){
         leaderboardArray = array<LeaderboardEntry@>();
     }
-    currentPbEntry = LeaderboardEntry();
-    currentPbEntry.entryType = EnumLeaderboardEntryType::PB;
-    currentPbEntry.desc = "PB";
-    timeDifferenceEntry = LeaderboardEntry();
+    currentPbEntry.time = -1;
+    currentPbEntry.position = -1;
+    timeDifferenceEntry.time = -1;
+    timeDifferenceEntry.position = -1;
 }

--- a/Model/Data.as
+++ b/Model/Data.as
@@ -45,8 +45,9 @@ const string blueColor = "\\$77f";
 const string redColor = "\\$f77";
 const string greyColor = "\\$888";
 const string brightGreyColor = "\\$aaa";
+const string greenColor = "\\$9f9";
 
-const string pluginName = "Extra Leaderboard positions";
+const string pluginName = "Extra Leaderboard Positions";
 
 string currentMapUid = "";
 
@@ -68,10 +69,13 @@ LeaderboardEntry@ timeDifferenceEntry = LeaderboardEntry();
 
 int playerCount = -1;
 
-int currentPbTime = -1;
-int currentPbPosition = -1;
-bool earlyPBUpdate = false;
-int earlyPbTime = -1;
+// Current local PB time, updated in Update() when new PB set.
+int currentTimePbLocal = -1;
+
+// PB entry we are currently displaying on the leaderboard.
+// When new PB set, updated and displayed immediately with the new time and an empty position value.
+// Position filled in later by API call.
+LeaderboardEntry@ currentPbEntry = LeaderboardEntry();
 
 float timerStartDelay = 30 *1000; // 30 seconds
 bool startupEnded = false;
@@ -79,6 +83,6 @@ bool startupEnded = false;
 bool validMap = false;
 
 //variables to check that we aren't currently in a "failed request" (server not responding or not updating the pb) to not spam the server
-int counterTries = 0;
 int maxTries = 10;
+int retryTimeLimit = 10000;
 bool failedRefresh = false;

--- a/Model/Enum.as
+++ b/Model/Enum.as
@@ -15,6 +15,13 @@ enum EnumDisplayMedal
     IN_GREY
 };
 
+enum EnumDisplayPersonalBest
+{
+    NORMAL,
+    IN_GREY,
+    IN_GREEN
+};
+
 enum EnumLeaderboardEntryType
 {
     UNKNOWN,

--- a/Model/LeaderboardEntry.as
+++ b/Model/LeaderboardEntry.as
@@ -30,10 +30,22 @@ class LeaderboardEntry{
      * Comparaison operator
      */
     int opCmp(LeaderboardEntry@ other){
-        if(position - other.position != 0)
-            return position - other.position;
-        else
+        // Position can be -1 if we have new PB on leaderboard without position from API yet, so sort by time first
+        if (time != other.time)
             return time - other.time;
+        else if (position != other.position) {
+            // Sort a temporary -1 position later i.e. greater than a valid position,
+            // since driving an equal time would typically be ranked later than the already existing record.
+            // We'll only have to wait a bit for the API to give the actual position for definitive sort.
+            if (position == -1)
+                return 1;
+            else if (other.position == -1)
+                return -1;
+            else
+                return position - other.position;
+        }
+        else
+            return 0;
     }
 
     /**

--- a/Render/Render.as
+++ b/Render/Render.as
@@ -285,7 +285,18 @@ void RenderTab(bool showRefresh = false){
                     break;
             }
         } else if(leaderboardArray[i].entryType == EnumLeaderboardEntryType::PB){
-            displayString = greenColor;
+            switch(personalBestDisplayMode){
+                case EnumDisplayPersonalBest::NORMAL:
+                    break;
+                case EnumDisplayPersonalBest::IN_GREY:
+                    displayString = greyColor;
+                    break;                   
+                case EnumDisplayPersonalBest::IN_GREEN:
+                    displayString = greenColor;
+                    break;                   
+                default:
+                    break;
+            }
         }
 
         //------------POSITION ICON--------

--- a/Render/RenderSettings.as
+++ b/Render/RenderSettings.as
@@ -48,6 +48,38 @@ void RenderSettingsCustomization(){
 
     showPb = UI::Checkbox("Show personal best", showPb);
 
+    UI::BeginDisabled(!showPb);
+
+    string pbDisplayComboTitle = "Invalid state";
+
+    switch(personalBestDisplayMode){
+        case EnumDisplayPersonalBest::NORMAL:
+            pbDisplayComboTitle = "Normal";
+            break;
+        case EnumDisplayPersonalBest::IN_GREY:
+            pbDisplayComboTitle = "In grey";
+            break;
+        case EnumDisplayPersonalBest::IN_GREEN:
+            pbDisplayComboTitle = "In green";
+            break;
+    }
+
+    if(UI::BeginCombo("Personal best display mode", pbDisplayComboTitle)){
+        if(UI::Selectable("Normal", personalBestDisplayMode == EnumDisplayPersonalBest::NORMAL)){
+            personalBestDisplayMode = EnumDisplayPersonalBest::NORMAL;
+        }
+        if(UI::Selectable("In grey", personalBestDisplayMode == EnumDisplayPersonalBest::IN_GREY)){
+            personalBestDisplayMode = EnumDisplayPersonalBest::IN_GREY;
+        }
+        if(UI::Selectable("In green", personalBestDisplayMode == EnumDisplayPersonalBest::IN_GREEN)){
+            personalBestDisplayMode = EnumDisplayPersonalBest::IN_GREEN;
+        }
+
+        UI::EndCombo();
+    }
+
+    UI::EndDisabled();
+
     UI::BeginDisabled(!useExternalAPI);
 
     UI::Text("\n\tPercentage ranking");

--- a/Render/RenderSettings.as
+++ b/Render/RenderSettings.as
@@ -48,12 +48,6 @@ void RenderSettingsCustomization(){
 
     showPb = UI::Checkbox("Show personal best", showPb);
 
-    UI::BeginDisabled(!showPb);
-
-    updatePbEarlySetting = UI::Checkbox("Update the PB early (updates the entry early while the whole leaderboard is refreshing)", updatePbEarlySetting);
-
-    UI::EndDisabled();
-
     UI::BeginDisabled(!useExternalAPI);
 
     UI::Text("\n\tPercentage ranking");

--- a/Settings/Settings.as
+++ b/Settings/Settings.as
@@ -24,6 +24,9 @@ int refreshTimer = 5;
 bool showPb = true;
 
 [Setting hidden]
+EnumDisplayPersonalBest personalBestDisplayMode = EnumDisplayPersonalBest::IN_GREEN;
+
+[Setting hidden]
 bool showPercentage = false;
 
 [Setting hidden]

--- a/Settings/Settings.as
+++ b/Settings/Settings.as
@@ -24,9 +24,6 @@ int refreshTimer = 5;
 bool showPb = true;
 
 [Setting hidden]
-bool updatePbEarlySetting = false;
-
-[Setting hidden]
 bool showPercentage = false;
 
 [Setting hidden]


### PR DESCRIPTION
Changes:
- Always show new PB immediately without waiting for API position update (removed corresponding setting)
- Show tooltip with countdown until next auto-refresh on refresh error icon
- Make the refresh error icon clickable to trigger immediate refresh
- Show clickable refresh icon even while non-failed status
- Add small delay and time limit to the internal retry logic
- Allow new PB to trigger refresh in failed refresh state (rate of new PBs unlikely to bother server)
- Don't show repeated position line when PB holds the position (unless it's needed to show a medal)
- Fix issue with external API still showing medals when disabled
