### PR TITLE
Proof-of-concept for getting regional leaderboard data.

### DIFF
--- a/Controller/Main.as
+++ b/Controller/Main.as
@@ -223,7 +223,7 @@ void RefreshLeaderboard(){
         // Make all the request in local (apart from impossible calls like medals above pb)
         array<Meta::PluginCoroutine@> coroutines;
         for(uint i = 0; i< allPositionData.Length; i++){
-            auto timeEntryFunc = startnew(SpecificTimeEntryCoroutine, Integer(allPositionData[i].position));
+            auto timeEntryFunc = startnew(SpecificTimeEntryCoroutine, PositionInteger(allPositionData[i].position, allPositionData[i].region));
             coroutines.InsertLast(timeEntryFunc);
         }
         auto medalEntryFunc = startnew(AddMedalsEntriesCoroutine);
@@ -276,10 +276,19 @@ class Integer{
     }
 }
 
+class PositionInteger{
+    int position;
+    int region;
+    PositionInteger(int position, int region){
+        this.position = position;
+        this.region = region;
+    }
+}
+
 void SpecificTimeEntryCoroutine(ref@ position){
     // cast ref to Integer
-    Integer@ positionInt = cast<Integer@>(position);
-    LeaderboardEntry@ timeEntry = GetSpecificTimeEntry(positionInt.value);
+    PositionInteger@ positionInt = cast<PositionInteger@>(position);
+    LeaderboardEntry@ timeEntry = GetSpecificTimeEntry(positionInt.position, positionInt.region);
     if(timeEntry !is null && timeEntry.isValid()){
         leaderboardArrayTmp.InsertLast(timeEntry);
     }

--- a/Model/LeaderboardEntry.as
+++ b/Model/LeaderboardEntry.as
@@ -13,6 +13,11 @@ class LeaderboardEntry{
     int position = -1;
 
     /**
+     * Region of the entry
+     */
+    string region = "";
+
+    /**
      * Really short description of the entry (medal type for example, or custom description)
      */
     string desc = "";
@@ -57,7 +62,7 @@ class LeaderboardEntry{
      * Custom Equality operator (only checks the position and the time compared to the regular equality operator)
      */
     bool customEquals(LeaderboardEntry@ other){
-        return position == other.position && time == other.time;
+        return position == other.position && time == other.time && region == other.region;
     }
 
 

--- a/Model/PositionData.as
+++ b/Model/PositionData.as
@@ -3,19 +3,22 @@
  */
  class PositionData {
     uint position;
+    uint region;
     string color;
     string icon;
     string textColor;
 
     PositionData() {
         position = 0;
+        region = 0;
         color = greyColor1;
         icon = Icons::Kenney::PodiumAlt;
         textColor = whiteColor;
     }
 
-    PositionData(uint position, const string &in color = greyColor1, const string &in icon = Icons::Kenney::PodiumAlt, const string &in textColor = whiteColor) {
+    PositionData(uint position, const string &in color = greyColor1, const string &in icon = Icons::Kenney::PodiumAlt, const string &in textColor = whiteColor, uint region = 0) {
         this.position = position;
+        this.region = region;
         this.color = color;
         this.icon = icon;
         this.textColor = textColor;
@@ -26,7 +29,7 @@
     }
 
     string Serialize() {
-        return color + " " + position + " " + icon + " " + textColor;
+        return color + " " + position + " " + icon + " " + textColor + " " + region;
     }
 
     void Deserialize(const string &in data) {
@@ -35,6 +38,11 @@
         position = Text::ParseInt(split[1]);
         icon = split[2];
         textColor = split[3];
+        if (split.Length > 4) {
+            region = Text::ParseInt(split[4]);
+        } else {
+            region = 0;
+        }
     }
 
     string GetColorIcon() {

--- a/Render/Render.as
+++ b/Render/Render.as
@@ -217,7 +217,7 @@ bool RenderInfoTab(){
  * Render the table with the custom leaderboard
  */
 void RenderTab(bool showRefresh = false){
-    int columnCount = 4;
+    int columnCount = 5;
     if(showPercentage){
         columnCount++;
     }
@@ -232,6 +232,8 @@ void RenderTab(bool showRefresh = false){
     // Position
     UI::TableNextColumn();
     UI::Text("Position");
+    UI::TableNextColumn();
+    UI::Text("Region");
     // Time
     UI::TableNextColumn();
     switch(currentMode){
@@ -297,6 +299,8 @@ void RenderTab(bool showRefresh = false){
         }else{
             UI::Text(displayString + "" + NumberToString(leaderboardArray[i].position));
         }
+        UI::TableNextColumn();
+        UI::Text(displayString + leaderboardArray[i].region);
 
         //------------TIME/SCORE-----------------
         UI::TableNextColumn();

--- a/Render/RenderSettings.as
+++ b/Render/RenderSettings.as
@@ -178,10 +178,11 @@ void RenderMedalSettings(){
  */
  bool GetPositionData(const string &in positionName, int uniqueId, PositionData& positionData, bool allowPositionChange = false){
     bool changed = false;
-    UI::BeginTable("PositionData#" + uniqueId, 4);
+    UI::BeginTable("PositionData#" + uniqueId, 5);
     UI::TableNextRow();
     UI::TableNextColumn();
     uint tmpPos = positionData.position;
+    uint tmpRegion = positionData.region;
     string tmpIcon = positionData.icon;
     string tmpColor = positionData.color;
     string tmpTextColor = positionData.textColor;
@@ -191,6 +192,10 @@ void RenderMedalSettings(){
         UI::Text(positionName);
     }
     UI::TableNextColumn();
+    if(allowPositionChange){
+        positionData.region = UI::InputInt("Region", positionData.region);
+        UI::TableNextColumn();
+    }
     if(UI::BeginCombo("Icon", positionData.icon)){
         for(uint i = 0; i < possibleIcons.Length; i++){
             if(UI::Selectable(possibleIcons[i], positionData.icon == possibleIcons[i])){
@@ -222,7 +227,7 @@ void RenderMedalSettings(){
     }
     UI::EndTable();
 
-    if(tmpPos != positionData.position || tmpIcon != positionData.icon || tmpColor != positionData.color || tmpTextColor != positionData.textColor){
+    if(tmpPos != positionData.position || tmpIcon != positionData.icon || tmpColor != positionData.color || tmpTextColor != positionData.textColor || tmpRegion != positionData.region){
         changed = true;
     }
 


### PR DESCRIPTION
This is only a proof-of-concept as the settings just expect you to insert the index of the region (0 for world, 1 for continent, ...), but it should work. The main issue is, that this requires multiple API calls (except for the top 5), but I don't think there is a way around it.

Properly implemented, this would implement #41.