### PR TITLE
Delay the display of the leaderboard to prevent flickering

### DIFF
--- a/Model/Data.as
+++ b/Model/Data.as
@@ -137,6 +137,9 @@ int currentTimePbLocal = -1;
 // Position filled in later by API call.
 LeaderboardEntry@ currentPbEntry = LeaderboardEntry();
 
+// Last time the car was above the speed threshold
+uint64 lastMovement = Time::get_Now();
+
 float timerStartDelay = 30 *1000; // 30 seconds
 bool startupEnded = false;
 

--- a/Render/Render.as
+++ b/Render/Render.as
@@ -46,7 +46,7 @@ void Render() {
             return;
         }
 
-        if(now - lastMovement > 1000)
+        if(now - lastMovement > unhideDelay)
             RenderWindows();
     }
 }

--- a/Render/Render.as
+++ b/Render/Render.as
@@ -21,8 +21,9 @@ void RenderMenu() {
 
 // ############################## WINDOW RENDER #############################
 
-void Render() {
+uint64 lastMovement = Time::get_Now();
 
+void Render() {
     if(!UserCanUseThePlugin()){
         return;
     }
@@ -36,10 +37,17 @@ void Render() {
     if(displayMode == EnumDisplayMode::HIDE_WHEN_DRIVING){
         auto state = VehicleState::ViewingPlayerState();
         if(state is null) return;
-        float currentSpeed = state.WorldVel.Length() * 3.6;
-        if(currentSpeed >= hiddingSpeedSetting) return;
 
-        RenderWindows();
+        uint64 now = Time::get_Now();
+
+        float currentSpeed = state.WorldVel.Length() * 3.6;
+        if(currentSpeed >= hiddingSpeedSetting) {
+            lastMovement = now;
+            return;
+        }
+
+        if(now - lastMovement > 1000)
+            RenderWindows();
     }
 }
 
@@ -112,13 +120,13 @@ void RenderWindows(){
 
 /**
  * Render the info tab
- * 
+ *
  * returns true if the refresh icon was rendered
  */
 bool RenderInfoTab(){
 
     // used to avoid showing extra blank space when player count is still checked while external api is unchecked
-    auto showPlayerCountEnabled = showPlayerCount && useExternalAPI; 
+    auto showPlayerCountEnabled = showPlayerCount && useExternalAPI;
 
     // if we don't show anything, we don't render the tab
     if(!(showMapName || showMapAuthor || showPlayerCountEnabled)){
@@ -151,7 +159,7 @@ bool RenderInfoTab(){
         UI::TableNextRow();
         UI::TableNextColumn();
         if(showMapAuthor){
-            UI::Text(greyColor4 + "Made by " + Text::StripFormatCodes(app.RootMap.MapInfo.AuthorNickName));    
+            UI::Text(greyColor4 + "Made by " + Text::StripFormatCodes(app.RootMap.MapInfo.AuthorNickName));
         }
         UI::TableNextColumn();
         UI::TableNextColumn();
@@ -275,7 +283,7 @@ void RenderTab(bool showRefresh = false){
     int i = 0;
     while(i < int(leaderboardArray.Length)){
         //We skip the pb if there's none
-        if( 
+        if(
             (leaderboardArray[i].entryType == EnumLeaderboardEntryType::PB && leaderboardArray[i].time == -1) ||
             (!showPb && leaderboardArray[i].entryType == EnumLeaderboardEntryType::PB) ){
             i++;

--- a/Render/Render.as
+++ b/Render/Render.as
@@ -21,8 +21,6 @@ void RenderMenu() {
 
 // ############################## WINDOW RENDER #############################
 
-uint64 lastMovement = Time::get_Now();
-
 void Render() {
     if(!UserCanUseThePlugin()){
         return;
@@ -34,20 +32,8 @@ void Render() {
         RenderWindows();
     }
 
-    if(displayMode == EnumDisplayMode::HIDE_WHEN_DRIVING){
-        auto state = VehicleState::ViewingPlayerState();
-        if(state is null) return;
-
-        uint64 now = Time::get_Now();
-
-        float currentSpeed = state.WorldVel.Length() * 3.6;
-        if(currentSpeed >= hiddingSpeedSetting) {
-            lastMovement = now;
-            return;
-        }
-
-        if(now - lastMovement > unhideDelay)
-            RenderWindows();
+    if(displayMode == EnumDisplayMode::HIDE_WHEN_DRIVING && IsIdle()){
+        RenderWindows();
     }
 }
 
@@ -367,4 +353,19 @@ void RenderTab(bool showRefresh = false){
     }
 
     UI::EndTable();
+}
+
+bool IsIdle(){
+    auto state = VehicleState::ViewingPlayerState();
+    if(state is null) return false;
+
+    uint64 now = Time::get_Now();
+
+    float currentSpeed = state.WorldVel.Length() * 3.6;
+    if(currentSpeed >= hiddingSpeedSetting) {
+        lastMovement = now;
+        return false;
+    }
+
+    return now - lastMovement > unhideDelay;
 }

--- a/Render/RenderSettings.as
+++ b/Render/RenderSettings.as
@@ -43,6 +43,11 @@ void RenderSettingsCustomization(){
         hiddingSpeedSetting = 0;
     }
 
+    unhideDelay = UI::InputInt("(ms) Unhide delay (if the hide when driving mode is active)", unhideDelay, 100);
+    if(unhideDelay < 0){
+        unhideDelay = 0;
+    }
+
     UI::Text("\n\tTimer");
 
     refreshTimer = UI::InputInt("Refresh timer every X (minutes)", refreshTimer);

--- a/Render/RenderSettings.as
+++ b/Render/RenderSettings.as
@@ -43,7 +43,7 @@ void RenderSettingsCustomization(){
         hiddingSpeedSetting = 0;
     }
 
-    unhideDelay = UI::InputInt("(ms) Unhide delay (if the hide when driving mode is active)", unhideDelay, 100);
+    unhideDelay = UI::InputInt("Delay (in ms) to wait before showing the window if you're below the hiding speed", unhideDelay, 100);
     if(unhideDelay < 0){
         unhideDelay = 0;
     }

--- a/Settings/Settings.as
+++ b/Settings/Settings.as
@@ -17,6 +17,9 @@ bool showSeparator = true;
 [Setting hidden]
 float hiddingSpeedSetting = 1.0f;
 
+[Setting hidden description="Time (milliseconds) before unhiding the overlay (only if Display Mode is set to HIDE_WHEN_DRIVING)"]
+int unhideDelay = 500;
+
 [Setting hidden name="Refresh timer (minutes)" description="The amount of time between automatic refreshes of the leaderboard. Must be over 0." min=1]
 int refreshTimer = 5;
 


### PR DESCRIPTION
Hello! I made this feature for myself that could fit in the public version.

This adds a timer that will delay the display of the leaderboard for an amount of time (a setting) that should prevent a few cases of flickering that I ran into:
- When switching between reversing/forward, the board would flash for a split second.
- Under specific circumstances the speed would quickly flicker between 0 and 1, causing the leaderboard to flicker.